### PR TITLE
[Feature] Evidence.py 구현

### DIFF
--- a/core/data_models.py
+++ b/core/data_models.py
@@ -19,7 +19,7 @@ class Profile:
 @dataclass
 class Evidence:
     name: str  # 증거품 이름(명사형) 
-    type: Literal["attorney", "prosecutor"]  # 제출 주체
+    type: Literal["attorney", "prosecutor"]  # 제출 주체 
     description: List[str]  # 증거 설명 (추가 가능)
     picture: str  # 사진 경로 (향후 구현)
 

--- a/core/data_models.py
+++ b/core/data_models.py
@@ -23,6 +23,17 @@ class Evidence:
     description: List[str]  # 증거 설명 (추가 가능)
     picture: str  # 사진 경로 (향후 구현)
 
+    @classmethod
+    def from_dict(cls, data: dict) -> 'Evidence':
+        desc = data.get("description", [])
+        if isinstance(desc, str):
+            desc = [desc]  # str to List
+        return cls(
+            name=data["name"],
+            type=data["type"],
+            description=desc,
+            picture=None
+        )
 
 # Controller에서 최종적으로 다른 모듈로 념겨줄 데이터 형식이에용
 # 아직 구현이 안 됐지만 이렇게 넘어올거라고 믿고 작업해주세요 

--- a/core/data_models.py
+++ b/core/data_models.py
@@ -21,7 +21,7 @@ class Evidence:
     name: str  # 증거품 이름(명사형) 
     type: Literal["attorney", "prosecutor"]  # 제출 주체
     description: List[str]  # 증거 설명 (추가 가능)
-    # picture: str  # 사진 경로 (향후 구현)
+    picture: str  # 사진 경로 (향후 구현)
 
 
 # Controller에서 최종적으로 다른 모듈로 념겨줄 데이터 형식이에용

--- a/core/evidence.py
+++ b/core/evidence.py
@@ -50,7 +50,7 @@ def make_evidence(case_data: Case, profiles: List[Profile]) -> List[Evidence]:
     chain = prompt | llm | parser
 
     response = chain.invoke({
-        "case_data":str_case_data,
+        "case_data": str_case_data,
         "profile": str_profiles_data
     })
     evidences = convert_data_class(response)

--- a/core/evidence.py
+++ b/core/evidence.py
@@ -1,0 +1,76 @@
+from langchain_openai import ChatOpenAI
+from langchain_core.prompts import PromptTemplate
+from langchain_core.pydantic_v1 import Field
+from langchain_core.output_parsers import (
+    JsonOutputParser
+)
+from pydantic import BaseModel
+from data_models import Case, Profile, Evidence
+from typing import List, Literal
+from dotenv import load_dotenv
+load_dotenv()
+
+CREATE_EVIDENCE_TEMPLATE = """
+다음의 사건 개요를 바탕으로 재판에 필요한 증거를 제공해주세요.
+{case_data}
+참여자 목록: {profile}
+
+단, 모든 증거는 재판에 참석한 인원과 연관이 있어야 합니다.
+증거품의 종류에는 제한이 없으나 답변은 다음의 형식을 따라야 합니다.
+
+name: 증거품 이름(명사)
+type: 증거 제출 주체(attorney, prosecutor)
+description: 증거에 대한 설명. 한 문장으로 설명하세요.
+
+제공된 세 개의 키워드명을 기준으로 JSON 형식으로 답하세요.
+"""
+
+
+class EvidenceModel(BaseModel):
+    name: str = Field(description="증거품 이름(명사형)")
+    type: Literal["attorney", "prosecutor"] = Field(description="제출 주체")
+    description: List[str] = Field(description="증거 설명")
+
+def get_llm():
+    return ChatOpenAI(model="gpt-4o-mini", temperature=1.0)
+
+
+def make_evidence(case_data: Case, profiles: List[Profile]) -> List[Evidence]:
+    str_case_data = format_case(case_data)
+    str_profiles_data = format_profiles(profiles)
+
+    llm = get_llm()
+    parser = JsonOutputParser(pydantic_object=EvidenceModel)
+    prompt = PromptTemplate(
+        template = CREATE_EVIDENCE_TEMPLATE,
+        input_variables=["case_data", "profile"],
+        partial_variables={"format_instructions": parser.get_format_instructions()}
+    )
+    chain = prompt | llm | parser
+
+    response = chain.invoke({
+        "case_data":str_case_data,
+        "profile": str_profiles_data
+    })
+    return convert_data_class(response)
+
+
+def format_case(case: Case) -> str:
+    return f"""사건 개요: {case.outline} 사건 내막: {case.behind}"""
+
+def format_profiles(raw_profiles):
+    profiles = "\n".join([f"- {p}" for p in raw_profiles])
+    return profiles
+
+def convert_data_class(data: List[dict]) -> List[Evidence]:
+    result = []
+    for item in data:
+        desc = item["description"]
+        if isinstance(desc, str):
+            desc = [desc] #str to List
+        result.append(Evidence(
+            name=item["name"],
+            type=item["type"],
+            description=desc
+        ))
+    return result

--- a/core/evidence.py
+++ b/core/evidence.py
@@ -1,11 +1,10 @@
 from langchain_openai import ChatOpenAI
 from langchain_core.prompts import PromptTemplate, ChatPromptTemplate
-from langchain_core.pydantic_v1 import Field
 from langchain_core.output_parsers import (
     JsonOutputParser,
     StrOutputParser
 )
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from data_models import Case, Profile, Evidence, CaseData
 from typing import List, Literal
 from dotenv import load_dotenv
@@ -181,6 +180,8 @@ def resize_img(input_path, output_path, target_size):
     except:
         return -1
     return 0
+
+
 
 ### TEST CODE ###
 c = Case(

--- a/core/evidence.py
+++ b/core/evidence.py
@@ -120,10 +120,11 @@ def get_naver_image(name): #이미지 처리 로직 개선 필요... 엉뚱한 �
     import urllib.request
     import requests
     import xml.etree.ElementTree as xmlET
-    import os
-
-    client_id = os.environ.get("X-Naver-Client-Id")
-    client_secret = os.environ.get("X-Naver-Client-Secret")
+    from dotenv import dotenv_values
+    
+    env = dotenv_values()
+    client_id = env.get("X_NAVER_CLIENT_ID")
+    client_secret = env.get("X_NAVER_CLIENT_SECRET")
 
     params = {
         'query': name,

--- a/core/evidence.py
+++ b/core/evidence.py
@@ -101,22 +101,11 @@ def format_profiles(raw_profiles):
     return profiles
 
 def convert_data_class(data: List[dict]) -> List[Evidence]:
-    import ast
-    if "evidence" in data:
+    # 데이터 형식 검증 
+    if isinstance(data, dict) and "evidence" in data:
         data = data["evidence"]
 
-    result = []
-    for item in data:
-        desc = item["description"]
-        if isinstance(desc, str):
-            desc = [desc] #str to List
-        result.append(Evidence(
-            name=item["name"],
-            type=item["type"],
-            picture=None,
-            description=desc
-        ))
-    return result
+    return [Evidence.from_dict(item) for item in data]
 
 def make_evidence_image(name):
     try:

--- a/core/evidence.py
+++ b/core/evidence.py
@@ -184,35 +184,36 @@ def resize_img(input_path, output_path, target_size):
 
 
 ### TEST CODE ###
-c = Case(
-    outline="""
-    피해자 김현수는 성공한 사업가로, 최근 은퇴 후 유산을 정리하고 있었습니다. 그의 조카 김민준은 김현수와 가까운 사이였으며, 유산 상속에 큰 관심을 보이고 있었습니다.
-    김현수는 자신의 저택에서 의식불명 상태로 발견되었고, 이틀 후 사망했습니다. 경찰은 김현수의 죽음이 단순한 사고가 아니라 누군가에 의해 계획된 범죄일 가능성을 제기했습니다. 사건 당일, 김민준은 저택을 방문했던 것으로 확인되었으며, 김현수의 유산에 관한 논의가 있었던 것으로 밝혀졌습니다.
-    """,
-    behind=""
-)
-plist = []
-plist.append(
-    Profile(
-        name="김민준",
-        type="suspect",
-        context="32세, 김현수의 조카로 현재 중소기업에서 근무 중입니다. 그는 평소 삼촌의 유산을 통해 사업 확장을 꿈꾸고 있었습니다. 사건 발생 시점에 김민준은 저택을 방문했으나 이후 친구들과 저녁 식사 모임이 있었다고 주장합니다."
+if __name__ == "__main__":
+    c = Case(
+        outline="""
+        피해자 김현수는 성공한 사업가로, 최근 은퇴 후 유산을 정리하고 있었습니다. 그의 조카 김민준은 김현수와 가까운 사이였으며, 유산 상속에 큰 관심을 보이고 있었습니다.
+        김현수는 자신의 저택에서 의식불명 상태로 발견되었고, 이틀 후 사망했습니다. 경찰은 김현수의 죽음이 단순한 사고가 아니라 누군가에 의해 계획된 범죄일 가능성을 제기했습니다. 사건 당일, 김민준은 저택을 방문했던 것으로 확인되었으며, 김현수의 유산에 관한 논의가 있었던 것으로 밝혀졌습니다.
+        """,
+        behind=""
     )
-)
-plist.append(
-    Profile(
-        name="이상훈",
-        type="witness",
-        context="사건 당일 저녁, 김민준이 친구와 함께 있었으며, 그의 행동에 의심스러운 점이 없었다는 증언입니다."
+    plist = []
+    plist.append(
+        Profile(
+            name="김민준",
+            type="suspect",
+            context="32세, 김현수의 조카로 현재 중소기업에서 근무 중입니다. 그는 평소 삼촌의 유산을 통해 사업 확장을 꿈꾸고 있었습니다. 사건 발생 시점에 김민준은 저택을 방문했으나 이후 친구들과 저녁 식사 모임이 있었다고 주장합니다."
+        )
     )
-)
-cd = CaseData(
-    case = c,
-    profiles=plist,
-    evidences=None
-)
-res = make_evidence(case_data=c, profiles=plist)
-print(res)
-print("\n\n")
-update_evidence_description(res[0], cd)
-print(res[0].description)
+    plist.append(
+        Profile(
+            name="이상훈",
+            type="witness",
+            context="사건 당일 저녁, 김민준이 친구와 함께 있었으며, 그의 행동에 의심스러운 점이 없었다는 증언입니다."
+        )
+    )
+    cd = CaseData(
+        case = c,
+        profiles=plist,
+        evidences=None
+    )
+    res = make_evidence(case_data=c, profiles=plist)
+    print(res)
+    print("\n\n")
+    update_evidence_description(res[0], cd)
+    print(res[0].description)


### PR DESCRIPTION
- 증거 생성 및 반환 구현
- description 업데이트 구현
- 네이버 이미지 검색으로 증거품 이미지 리소스 저장, Evidence DataClass에 이미지 경로 저장
- 임시 테스트 코드 작성(Evidence.py)
- 증거품 이력 추적은 일단 보류

컨트롤러 쪽의 핸들링 방법이 구체화되지 않아서 대략 예상하여 코드를 작성했습니다.
일단은 관련 인물을 List[Profile]로 입력받아 증거를 생성하나, 용의자만 받는 것도 좋아 보이네요.

추후 개선점:
- 증거품의 이름이 모호한 경우(통화 내역, 위치 기록 등)의 이미지 구현방법 구체화 필요
- description 업데이트 출력 고도화 필요