### PR TITLE
[Feature] evidence 모듈을 컨트롤러에서 호출하고 결과값을 UI 로 넘겨줌

### DIFF
--- a/core/controller.py
+++ b/core/controller.py
@@ -67,15 +67,7 @@ class CaseDataManager:
     @classmethod
     async def generate_case_behind(cls, callback=None):
         chain = build_case_behind_chain(cls._case.outline, cls._profiles) 
-        result = ""
-        
-        for chunk in chain.stream({}):
-            content = chunk.content if hasattr(chunk, 'content') else chunk
-            result += content
-            
-            if callback:
-                callback(content, result)
-    
+        result = cls._handle_stream(chain, callback)
         return result
     
     # 프로필 파싱 및 저장하는 내부 메소드 

--- a/core/controller.py
+++ b/core/controller.py
@@ -4,7 +4,7 @@ load_dotenv()
 from langchain_openai import ChatOpenAI
 from typing import List, Dict
 from case_generation.case_builder import build_case_chain, build_character_chain,build_case_behind_chain
-from evidence import make_evidence, update_evidence
+from evidence import make_evidence
 from data_models import CaseData, Case, Profile, Evidence
 import asyncio
 
@@ -203,5 +203,5 @@ if __name__ == "__main__":
     asyncio.run(CaseDataManager.initialize())  # 비동기 호출
     asyncio.run(CaseDataManager.generate_case_stream())  # 비동기 호출
     asyncio.run(CaseDataManager.generate_profiles_stream())  # 비동기 호출  
-
-    
+    asyncio.run(CaseDataManager.generate_evidences())  # 비동기 호출
+    print(CaseDataManager.get_case_data())

--- a/core/controller.py
+++ b/core/controller.py
@@ -63,6 +63,8 @@ class CaseDataManager:
         asyncio.create_task(cls.parse_and_store_profiles(result)) 
         return result
     
+    # 호출 시점 : 최종 판결과 함께 또는 최종 판결을 읽고 있을 때 
+    # 매개변수로 변경된 증거 리스트도 포함 
     @classmethod
     async def generate_case_behind(cls, callback=None):
         chain = build_case_behind_chain(cls._case.outline, cls._profiles) 

--- a/core/controller.py
+++ b/core/controller.py
@@ -4,6 +4,7 @@ load_dotenv()
 from langchain_openai import ChatOpenAI
 from typing import List, Dict
 from case_generation.case_builder import build_case_chain, build_character_chain,build_case_behind_chain
+from evidence import make_evidence, update_evidence
 from data_models import CaseData, Case, Profile, Evidence
 import asyncio
 
@@ -60,7 +61,7 @@ class CaseDataManager:
 
         # 비동기 작업 후 다른 함수 호출 (즉시 반환)
         # 내용을 파싱해서 profiles 리스트에 저장 하는 함수를 호출해야함 비동기로 !!
-        asyncio.create_task(cls.parse_and_store_profiles(result)) 
+        asyncio.create_task(cls._parse_and_store_profiles(result)) 
         return result
     
     # 호출 시점 : 최종 판결과 함께 또는 최종 판결을 읽고 있을 때 
@@ -79,16 +80,16 @@ class CaseDataManager:
     
         return result
     
-
+    # 프로필 파싱 및 저장하는 내부 메소드 
     @classmethod
-    async def parse_and_store_profiles(cls, result: str):
+    async def _parse_and_store_profiles(cls, result: str):
         print("parse_and_store_profiles 실행")
-        profiles = cls.parse_character_template(result)  # 결과값을 파싱하여 프로필 리스트 생성
-        cls.set_profiles(profiles)  # 프로필 리스트를 저장하는 메소드 호출
+        profiles = cls._parse_character_template(result)
+        cls.set_profiles(profiles)
         print(profiles)
 
-    @classmethod
-    def parse_character_template(cls, template: str) -> List[Profile]:
+    @staticmethod
+    def _parse_character_template(template: str) -> List[Profile]:
         profiles = []
         
         # 각 인물 블록을 분리
@@ -96,7 +97,7 @@ class CaseDataManager:
         
         for block in character_blocks:
             lines = block.strip().split('\n')
-            if len(lines) < 4:  # 최소 4줄이 필요
+            if len(lines) < 4: 
                 continue
             
             # 이름, 직업, 성격, 배경 추출

--- a/core/controller.py
+++ b/core/controller.py
@@ -53,6 +53,7 @@ class CaseDataManager:
         # evidence 생성
         evidences = make_evidence(case_data=cls._case, profiles=cls._profiles)
         cls._evidences = evidences 
+        cls._case_data = CaseData(cls._case, cls._profiles, cls._evidences)
         
         # UI 콜백 처리
         if callback:
@@ -202,4 +203,5 @@ if __name__ == "__main__":
     asyncio.run(CaseDataManager.initialize())  # 비동기 호출
     asyncio.run(CaseDataManager.generate_case_stream())  # 비동기 호출
     asyncio.run(CaseDataManager.generate_profiles_stream())  # 비동기 호출  
+
     

--- a/core/evidence.py
+++ b/core/evidence.py
@@ -10,6 +10,9 @@ from typing import List, Literal
 from dotenv import load_dotenv
 load_dotenv()
 
+from controller import CaseDataManager
+import asyncio
+
 CREATE_EVIDENCE_TEMPLATE = """
 다음의 사건 개요를 바탕으로 재판에 필요한 증거를 제공해주세요.
 {case_data}
@@ -175,35 +178,13 @@ def resize_img(input_path, output_path, target_size):
 
 ### TEST CODE ###
 if __name__ == "__main__":
-    c = Case(
-        outline="""
-        피해자 김현수는 성공한 사업가로, 최근 은퇴 후 유산을 정리하고 있었습니다. 그의 조카 김민준은 김현수와 가까운 사이였으며, 유산 상속에 큰 관심을 보이고 있었습니다.
-        김현수는 자신의 저택에서 의식불명 상태로 발견되었고, 이틀 후 사망했습니다. 경찰은 김현수의 죽음이 단순한 사고가 아니라 누군가에 의해 계획된 범죄일 가능성을 제기했습니다. 사건 당일, 김민준은 저택을 방문했던 것으로 확인되었으며, 김현수의 유산에 관한 논의가 있었던 것으로 밝혀졌습니다.
-        """,
-        behind=""
-    )
-    plist = []
-    plist.append(
-        Profile(
-            name="김민준",
-            type="suspect",
-            context="32세, 김현수의 조카로 현재 중소기업에서 근무 중입니다. 그는 평소 삼촌의 유산을 통해 사업 확장을 꿈꾸고 있었습니다. 사건 발생 시점에 김민준은 저택을 방문했으나 이후 친구들과 저녁 식사 모임이 있었다고 주장합니다."
-        )
-    )
-    plist.append(
-        Profile(
-            name="이상훈",
-            type="witness",
-            context="사건 당일 저녁, 김민준이 친구와 함께 있었으며, 그의 행동에 의심스러운 점이 없었다는 증언입니다."
-        )
-    )
-    cd = CaseData(
-        case = c,
-        profiles=plist,
-        evidences=None
-    )
-    res = make_evidence(case_data=c, profiles=plist)
+    asyncio.run(CaseDataManager.initialize())  # CaseDataManager 초기화 
+    asyncio.run(CaseDataManager.generate_case_stream())  # case 생성 
+    asyncio.run(CaseDataManager.generate_profiles_stream())  # 프로필 생성
+    res = make_evidence(case_data=CaseDataManager.get_case(), 
+                        profiles=CaseDataManager.get_profiles())
     print(res)
-    print("\n\n")
-    update_evidence_description(res[0], cd)
-    print(res[0].description)
+    # print("\n\n")
+    # update_evidence_description(res[0], cd)
+    # print(res[0].description)
+

--- a/core/evidence.py
+++ b/core/evidence.py
@@ -184,6 +184,34 @@ if __name__ == "__main__":
     res = make_evidence(case_data=CaseDataManager.get_case(), 
                         profiles=CaseDataManager.get_profiles())
     print(res)
+    # c = Case(
+    #     outline="""
+    #     피해자 김현수는 성공한 사업가로, 최근 은퇴 후 유산을 정리하고 있었습니다. 그의 조카 김민준은 김현수와 가까운 사이였으며, 유산 상속에 큰 관심을 보이고 있었습니다.
+    #     김현수는 자신의 저택에서 의식불명 상태로 발견되었고, 이틀 후 사망했습니다. 경찰은 김현수의 죽음이 단순한 사고가 아니라 누군가에 의해 계획된 범죄일 가능성을 제기했습니다. 사건 당일, 김민준은 저택을 방문했던 것으로 확인되었으며, 김현수의 유산에 관한 논의가 있었던 것으로 밝혀졌습니다.
+    #     """,
+    #     behind=""
+    # )
+    # plist = []
+    # plist.append(
+    #     Profile(
+    #         name="김민준",
+    #         type="suspect",
+    #         context="32세, 김현수의 조카로 현재 중소기업에서 근무 중입니다. 그는 평소 삼촌의 유산을 통해 사업 확장을 꿈꾸고 있었습니다. 사건 발생 시점에 김민준은 저택을 방문했으나 이후 친구들과 저녁 식사 모임이 있었다고 주장합니다."
+    #     )
+    # )
+    # plist.append(
+    #     Profile(
+    #         name="이상훈",
+    #         type="witness",
+    #         context="사건 당일 저녁, 김민준이 친구와 함께 있었으며, 그의 행동에 의심스러운 점이 없었다는 증언입니다."
+    #     )
+    # )
+    # cd = CaseData(
+    #     case = c,
+    #     profiles=plist,
+    #     evidences=None
+    # )
+    # res = make_evidence(case_data=c, profiles=plist)
     # print("\n\n")
     # update_evidence_description(res[0], cd)
     # print(res[0].description)

--- a/core/evidence.py
+++ b/core/evidence.py
@@ -10,8 +10,8 @@ from typing import List, Literal
 from dotenv import load_dotenv
 load_dotenv()
 
-from controller import CaseDataManager
-import asyncio
+# from controller import CaseDataManager 테스트 할 때만 돌려보세용 
+# import asyncio 여기도 주석해제
 
 CREATE_EVIDENCE_TEMPLATE = """
 다음의 사건 개요를 바탕으로 재판에 필요한 증거를 제공해주세요.
@@ -178,41 +178,42 @@ def resize_img(input_path, output_path, target_size):
 
 ### TEST CODE ###
 if __name__ == "__main__":
-    asyncio.run(CaseDataManager.initialize())  # CaseDataManager 초기화 
-    asyncio.run(CaseDataManager.generate_case_stream())  # case 생성 
-    asyncio.run(CaseDataManager.generate_profiles_stream())  # 프로필 생성
-    res = make_evidence(case_data=CaseDataManager.get_case(), 
-                        profiles=CaseDataManager.get_profiles())
-    print(res)
-    # c = Case(
-    #     outline="""
-    #     피해자 김현수는 성공한 사업가로, 최근 은퇴 후 유산을 정리하고 있었습니다. 그의 조카 김민준은 김현수와 가까운 사이였으며, 유산 상속에 큰 관심을 보이고 있었습니다.
-    #     김현수는 자신의 저택에서 의식불명 상태로 발견되었고, 이틀 후 사망했습니다. 경찰은 김현수의 죽음이 단순한 사고가 아니라 누군가에 의해 계획된 범죄일 가능성을 제기했습니다. 사건 당일, 김민준은 저택을 방문했던 것으로 확인되었으며, 김현수의 유산에 관한 논의가 있었던 것으로 밝혀졌습니다.
-    #     """,
-    #     behind=""
-    # )
-    # plist = []
-    # plist.append(
-    #     Profile(
-    #         name="김민준",
-    #         type="suspect",
-    #         context="32세, 김현수의 조카로 현재 중소기업에서 근무 중입니다. 그는 평소 삼촌의 유산을 통해 사업 확장을 꿈꾸고 있었습니다. 사건 발생 시점에 김민준은 저택을 방문했으나 이후 친구들과 저녁 식사 모임이 있었다고 주장합니다."
-    #     )
-    # )
-    # plist.append(
-    #     Profile(
-    #         name="이상훈",
-    #         type="witness",
-    #         context="사건 당일 저녁, 김민준이 친구와 함께 있었으며, 그의 행동에 의심스러운 점이 없었다는 증언입니다."
-    #     )
-    # )
-    # cd = CaseData(
-    #     case = c,
-    #     profiles=plist,
-    #     evidences=None
-    # )
-    # res = make_evidence(case_data=c, profiles=plist)
-    # print("\n\n")
-    # update_evidence_description(res[0], cd)
-    # print(res[0].description)
+    # CaseDataManager import 한 뒤에 테스트 할 때만 돌려보세용  
+    # asyncio.run(CaseDataManager.initialize())  # CaseDataManager 초기화 
+    # asyncio.run(CaseDataManager.generate_case_stream())  # case 생성 
+    # asyncio.run(CaseDataManager.generate_profiles_stream())  # 프로필 생성
+    # res = make_evidence(case_data=CaseDataManager.get_case(), 
+    #                     profiles=CaseDataManager.get_profiles())
+    # print(res)
+    c = Case(
+        outline="""
+        피해자 김현수는 성공한 사업가로, 최근 은퇴 후 유산을 정리하고 있었습니다. 그의 조카 김민준은 김현수와 가까운 사이였으며, 유산 상속에 큰 관심을 보이고 있었습니다.
+        김현수는 자신의 저택에서 의식불명 상태로 발견되었고, 이틀 후 사망했습니다. 경찰은 김현수의 죽음이 단순한 사고가 아니라 누군가에 의해 계획된 범죄일 가능성을 제기했습니다. 사건 당일, 김민준은 저택을 방문했던 것으로 확인되었으며, 김현수의 유산에 관한 논의가 있었던 것으로 밝혀졌습니다.
+        """,
+        behind=""
+    )
+    plist = []
+    plist.append(
+        Profile(
+            name="김민준",
+            type="suspect",
+            context="32세, 김현수의 조카로 현재 중소기업에서 근무 중입니다. 그는 평소 삼촌의 유산을 통해 사업 확장을 꿈꾸고 있었습니다. 사건 발생 시점에 김민준은 저택을 방문했으나 이후 친구들과 저녁 식사 모임이 있었다고 주장합니다."
+        )
+    )
+    plist.append(
+        Profile(
+            name="이상훈",
+            type="witness",
+            context="사건 당일 저녁, 김민준이 친구와 함께 있었으며, 그의 행동에 의심스러운 점이 없었다는 증언입니다."
+        )
+    )
+    cd = CaseData(
+        case = c,
+        profiles=plist,
+        evidences=None
+    )
+    res = make_evidence(case_data=c, profiles=plist)
+    print("\n\n")
+    update_evidence_description(res[0], cd)
+    print(res[0].description)
 

--- a/core/evidence.py
+++ b/core/evidence.py
@@ -10,8 +10,8 @@ from typing import List, Literal
 from dotenv import load_dotenv
 load_dotenv()
 
-# from controller import CaseDataManager 테스트 할 때만 돌려보세용 
-# import asyncio 여기도 주석해제
+# from controller import CaseDataManager #테스트 할 때만 돌려보세용 
+# import asyncio #여기도 주석해제
 
 CREATE_EVIDENCE_TEMPLATE = """
 다음의 사건 개요를 바탕으로 재판에 필요한 증거를 제공해주세요.
@@ -105,8 +105,25 @@ def format_profiles(raw_profiles):
 
 def convert_data_class(data: List[dict]) -> List[Evidence]:
     # 데이터 형식 검증 
-    if isinstance(data, dict) and "evidence" in data:
-        data = data["evidence"]
+    """
+    evidences = convert_data_class(response)
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    File "D:\WS\pi5-local-app\core\evidence.py", line 111, in convert_data_class
+    return [Evidence.from_dict(item) for item in data]
+            ^^^^^^^^^^^^^^^^^^^^^^^^
+    File "D:\WS\pi5-local-app\core\data_models.py", line 28, in from_dict       
+    desc = data.get("description", [])
+           ^^^^^^^^
+    AttributeError: 'str' object has no attribute 'get'
+    이 부분에서 가끔씩 뻑남 에러처리 해줘야 할듯 data가 리스트 타입이 아니고 str로 잡히네 
+    data 찍어보니까 data["증거품"] 이렇게 내려올 때가 있음 계속 테스팅 하면서 예외처리 잡아줘야 될듯 
+    """
+    print("convert_data_class의 data:", data)
+    if isinstance(data, dict):
+        if "증거품" in data:
+            data = data["증거품"]
+        elif "evidence" in data:
+            data = data["evidence"]
 
     return [Evidence.from_dict(item) for item in data]
 


### PR DESCRIPTION
- UI가 멈춰있는 것처럼 보이는 게 싫어서 최대한 백으로 뺄 수 있는 건 비동기로 빼려고 함 await도 안 쓰고 
- evidence.make_evidence() 가 dataclss 정의를 알잘딱깔센으로 잘 따라서 너무 편했음 👍👍 개굿
- 덕분에 코드는 빨리 짰는데 비동기로 한다 깝친다고 계속 테스팅 보면서 예외처리 하느라고 시간 좀 잡아먹었음 
- 개발 중에는 코드는 대충 돌아가게만 하고 나중에 리팩터링 해야되는데 왤케 작은 부분에 집착하게 되는지 몰겠음 ㄱ- 


```
#evidence.py
def : conver_data_class(data: List[dict]) -> List[Evidence] " 
    print("convert_data_class의 data:", data)
    if isinstance(data, dict):
        if "증거품" in data:
            data = data["증거품"]
        elif "evidence" in data:
            data = data["evidence"]

    return [Evidence.from_dict(item) for item in data]
  ```
  
  - 이 부분이 가끔씩 뻑나는 경우가 있었는데 invoke 했을 때 좀 지멋대로 담겨서 오는 경우가 있나봄 예외처리 좀더 해줘야 할듯
  
  
 앞으로 작업할 내용 : 
 - 일단 이 상태로 main에 통합
 - streamlit state로 데이터클래스 넣어놨음 참고인은 이거 기반으로 구현
 - 패널 나눠서 사이드 바로 출력하던 거 기존 코드랑 수동 병합해야 함 
 - controller에 CaseDataManager가 점점 헤비해지고 있음 시간 나면 같은 파일 내에서라도 클래스 분리하고 싶은데 이건 후순위 
 - evidence 에서 기능 개선하고 싶었던 부분들 예시 코드 짜서 넘기기 
 - interrogator 모듈 구조 짜야 함 
 - case_builder 템플릿 수정 많이 봐야 할듯 
 
 
 - 심문 기능 개발하고 UI 통합하면 GUI 빼고는 SW개발 MVP는 끝났고  
 - case_builder-evidence-interrogator 성능 개선을 테스팅 보면서 살살 병렬로 진행
 - 하드웨어 모듈과 통합을 위해서 RestAPI를 정의해줄 때가 왔음 .. 
 	- 따로 game controller를 만드는 게 아닌 이상 chat.py랑 결합도가 높지 싶음 //이게 논리적으로 맞나 ? ;; 
 	- 이를테면 텍스트가 생성되고 화면에 뜨는 타이밍에서 case.outline의 텍스트를 보내기 
 	- 부저 버튼을 누르면 turn이 검사측에 넘어가게 하기 
 	- 아무튼 이 부분은 머리가 복잡 