### PR TITLE
[Build] RestAPI 통신을 위한 공용 네트워크 지정 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,7 @@ services:
     command: streamlit run core/chat.py
     ports:
       - "8501:8501"  # Streamlit 기본 포트
+      - "3500:3500"  # hardware 통신용 포트
     networks:
       - logicourt_network
     # ports 설정 
@@ -58,6 +59,8 @@ services:
   #     - base
   #   volumes:
   #     - data:/data  # 공유 볼륨을 마운트
+  #   ports:
+  #     - "3500:3500"  # hardware 통신용 포트
   #   networks:
   #     - logicourt_network
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,8 @@ services:
     command: streamlit run core/chat.py
     ports:
       - "8501:8501"  # Streamlit 기본 포트
+    networks:
+      - logicourt_network
     # ports 설정 
 
 
@@ -56,6 +58,8 @@ services:
   #     - base
   #   volumes:
   #     - data:/data  # 공유 볼륨을 마운트
+  #   networks:
+  #     - logicourt_network
 
 volumes:
   data:
@@ -71,3 +75,7 @@ volumes:
 #     limits:
 #       cpus: "4" # 4개의 코어 사용
 #       memory: "8g" # 8GB의 메모리 사용  
+
+networks:
+  logicourt_network:
+    driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
     command: streamlit run core/chat.py
     ports:
       - "8501:8501"  # Streamlit 기본 포트
-      - "3500:3500"  # hardware 통신용 포트
+      - "8000:8000"  # hardware 통신용 포트
     networks:
       - logicourt_network
     # ports 설정 
@@ -60,7 +60,7 @@ services:
   #   volumes:
   #     - data:/data  # 공유 볼륨을 마운트
   #   ports:
-  #     - "3500:3500"  # hardware 통신용 포트
+  #     - "8000:8000"  # hardware 통신용 포트
   #   networks:
   #     - logicourt_network
 


### PR DESCRIPTION
- hardware 쪽도 추가해놓음 
- port 번호는 8000번 
- 다른 컨테이너와 통신할 때 `http://core:8000/api/endpoint` 이런 식으로 접근하면 됨 