### PR TITLE
feat: 검사, 변호사 화면 텍스트 입력 기능 GameController 연동

### DIFF
--- a/core/game_controller.py
+++ b/core/game_controller.py
@@ -111,7 +111,7 @@ class GameController(QObject):
         Args:
             text: 사용자가 입력한 텍스트
         Returns:
-            bool: 처리 성공 여부
+             bool: True면 턴 전환, False면 턴 전환 없음
         """
         if not text.strip():
             return False

--- a/core/test_prosecutor_screen.py
+++ b/core/test_prosecutor_screen.py
@@ -29,6 +29,7 @@ class TestApp:
 
     async def run(self):
         await self.controller.initialize()
+        await self.controller.start_game()
         self.window.show()
 
 if __name__ == "__main__":

--- a/core/test_prosecutor_screen.py
+++ b/core/test_prosecutor_screen.py
@@ -1,0 +1,43 @@
+import sys
+import os
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+#qasync => PyQt5 + asyncio를 자연스럽게 통합 pip install qasync
+
+import asyncio
+from PyQt5.QtWidgets import QApplication
+from qasync import QEventLoop, asyncSlot
+
+from ui.screen.prosecutor_screen import ProsecutorScreen
+from core.game_controller import GameController
+
+
+def dummy(): pass
+
+class TestApp:
+    def __init__(self):
+        self.controller = GameController.get_instance()
+        self.window = ProsecutorScreen(
+            game_controller=self.controller,
+            on_switch_to_lawyer=dummy,
+            on_request_judgement=dummy,
+            on_interrogate=dummy,
+            case_summary_text="⚖ 사건 개요 테스트용",
+            profiles_data_list=[{'name': '김소현', 'type': 'defendant', 'gender': 'female', 'age': 29, 'context': '피고인 설명'}],
+            evidences_data_list=[{'name': '독극물 잔', 'type': 'prosecutor', 'description': ['잔에서 독극물 검출됨']}]
+        )
+
+    async def run(self):
+        await self.controller.initialize()
+        self.window.show()
+
+if __name__ == "__main__":
+    app = QApplication(sys.argv)
+    loop = QEventLoop(app)
+    asyncio.set_event_loop(loop)
+
+    test = TestApp()
+
+    with loop:
+        loop.create_task(test.run())
+        loop.run_forever()

--- a/core/ui/screen/lawyer_screen.py
+++ b/core/ui/screen/lawyer_screen.py
@@ -1,6 +1,6 @@
 from PyQt5.QtWidgets import (
     QWidget, QVBoxLayout, QLabel, QPushButton, QHBoxLayout,
-    QSizePolicy, QMessageBox, QGridLayout
+    QSizePolicy, QMessageBox, QGridLayout,QInputDialog
 )
 from PyQt5.QtCore import Qt
 # from PyQt5.QtGui import QIcon, QPixmap # Not directly needed if using common components
@@ -14,6 +14,7 @@ from ui.common_components import (
     show_case_dialog_common, show_evidences_common, show_full_profiles_dialog_common
 )
 import re, asyncio
+from qasync import asyncSlot
 
 
 class LawyerScreen(QWidget):
@@ -60,7 +61,7 @@ class LawyerScreen(QWidget):
         menu_layout.setSpacing(15)
         menu_layout.addWidget(make_button("사건개요", self.show_case_dialog))
         menu_layout.addWidget(make_button("증거품 확인", self.show_evidences))
-        menu_layout.addWidget(make_button("텍스트입력", self.show_text_input_placeholder))
+        menu_layout.addWidget(make_button("텍스트입력", self.show_text_input_dialog))
         menu_layout.addWidget(make_button("➤ 심문하기", self.handle_interrogate))
         menu_layout.addStretch()
 
@@ -146,16 +147,14 @@ class LawyerScreen(QWidget):
         self.btn_mic.set_icon_on(self.mic_on)
 
     def toggle_mic_action(self):
-        print("🧪 [ProsecutorScreen] Mic 버튼 클릭됨")
+        print("Mic 버튼 클릭됨")
 
         if self.game_controller:
-            print("🧪 game_controller 연결됨 → mic_on =", self.mic_on)
+            print("game_controller 연결됨 → mic_on =", self.mic_on)
 
             if not self.mic_on:
-                print("✅ record_start() 호출")
                 asyncio.create_task(self.game_controller.record_start())
             else:
-                print("✅ record_end() 호출")
                 asyncio.create_task(self.game_controller.record_end())
         else:
             print("❌ game_controller 없음")
@@ -193,14 +192,17 @@ class LawyerScreen(QWidget):
     def show_evidences(self):
         show_evidences_common(self, self.evidences_list, attorney_first=True)
 
-    def show_text_input_placeholder(self):
-        # Eventually, this would allow typing arguments.
-        # For now, it might just send a generic statement or do nothing.
-        # text, ok = QInputDialog.getText(self, "변론 입력", "주장할 내용을 입력하세요:")
-        # if ok and text and self.game_controller:
-        #     self.game_controller.user_input(text)
-        QMessageBox.information(self, "텍스트입력", "변호사측 텍스트 입력 기능은 구현 중입니다.", QMessageBox.Ok)
-
+    @asyncSlot()
+    async def show_text_input_dialog(self):
+        text, ok = QInputDialog.getText(self, "텍스트 입력", "전송할 내용을 입력하세요:")
+        if ok and text.strip():
+            print(f"🧪 입력됨: {text}")
+            if self.game_controller:
+                await self.game_controller.user_input(text)
+            else:
+                print("❌ game_controller 없음")
+        else:
+            print("⛔ 입력 취소 또는 공백")
 
     def show_full_profiles_dialog(self):
         show_full_profiles_dialog_common(self, self.profiles_list)

--- a/core/ui/screen/prosecutor_screen.py
+++ b/core/ui/screen/prosecutor_screen.py
@@ -1,6 +1,6 @@
 from PyQt5.QtWidgets import (
     QWidget, QVBoxLayout, QLabel, QPushButton, QHBoxLayout,
-    QSizePolicy, QMessageBox, QGridLayout
+    QSizePolicy, QMessageBox, QGridLayout,QInputDialog
 )
 from PyQt5.QtCore import Qt
 # from PyQt5.QtGui import QIcon, QPixmap # Not directly needed
@@ -14,6 +14,7 @@ from ui.common_components import (
     show_case_dialog_common, show_evidences_common, show_full_profiles_dialog_common
 )
 import re, asyncio
+from qasync import asyncSlot
 
 
 class ProsecutorScreen(QWidget):
@@ -59,7 +60,8 @@ class ProsecutorScreen(QWidget):
         menu_layout.setSpacing(15)
         menu_layout.addWidget(make_button("사건개요", self.show_case_dialog))
         menu_layout.addWidget(make_button("증거품 확인", self.show_evidences))
-        menu_layout.addWidget(make_button("텍스트입력", self.show_text_input_placeholder))
+        menu_layout.addWidget(make_button("텍스트입력", self.show_text_input_dialog))
+
         menu_layout.addWidget(make_button("➤ 심문하기", self.handle_interrogate))
         menu_layout.addStretch()
 
@@ -141,16 +143,14 @@ class ProsecutorScreen(QWidget):
         self.btn_mic.set_icon_on(self.mic_on)
 
     def toggle_mic_action(self):
-        print("🧪 [ProsecutorScreen] Mic 버튼 클릭됨")
+        print("Mic 버튼 클릭됨")
 
         if self.game_controller:
-            print("🧪 game_controller 연결됨 → mic_on =", self.mic_on)
+            print("game_controller 연결됨 → mic_on =", self.mic_on)
 
             if not self.mic_on:
-                print("✅ record_start() 호출")
                 asyncio.create_task(self.game_controller.record_start())
             else:
-                print("✅ record_end() 호출")
                 asyncio.create_task(self.game_controller.record_end())
         else:
             print("❌ game_controller 없음")
@@ -180,73 +180,17 @@ class ProsecutorScreen(QWidget):
     def show_evidences(self):
         show_evidences_common(self, self.evidences_list, attorney_first=False)
 
-    def show_text_input_placeholder(self):
-        QMessageBox.information(self, "텍스트입력", "검사측 텍스트 입력 기능은 구현 중입니다.", QMessageBox.Ok)
-
+    @asyncSlot()
+    async def show_text_input_dialog(self):
+        text, ok = QInputDialog.getText(self, "텍스트 입력", "전송할 내용을 입력하세요:")
+        if ok and text.strip():
+            print(f"🧪 입력됨: {text}")
+            if self.game_controller:
+                await self.game_controller.user_input(text)
+            else:
+                print("❌ game_controller 없음")
+        else:
+            print("⛔ 입력 취소 또는 공백")
 
     def show_full_profiles_dialog(self):
         show_full_profiles_dialog_common(self, self.profiles_list)
-
-
-# 테스트 코드
-if __name__ == "__main__":
-    import sys
-    import os
-    # 경로 설정
-    sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
-    
-    try:
-        import asyncio
-        from PyQt5.QtWidgets import QApplication
-        from qasync import QEventLoop
-        from game_controller import GameController
-    except ImportError as e:
-        print(f"필요한 모듈을 불러올 수 없습니다: {e}")
-        sys.exit(1)
-
-    def dummy_function(): pass
-
-    class ProsecutorTestApp:
-        def __init__(self):
-            self.controller = GameController.get_instance()
-            
-            # 테스트용 데이터
-            test_profiles = [
-                {'name': '김소현', 'type': 'defendant', 'gender': 'female', 'age': 29, 'context': '피고인 설명'},
-            ]
-            
-            test_evidences = [
-                {'name': '독극물 잔', 'type': 'prosecutor', 'description': ['잔에서 독극물 검출됨', '지문 분석 결과 피고인의 것으로 확인']},
-            ]
-            
-            self.window = ProsecutorScreen(
-                game_controller=self.controller,
-                on_switch_to_lawyer=dummy_function,
-                on_request_judgement=dummy_function,
-                on_interrogate=dummy_function,
-                case_summary_text="""⚖ 사건 개요 (테스트용)""",
-                profiles_data_list=test_profiles,
-                evidences_data_list=test_evidences
-            )
-
-        async def run(self):
-            try:
-                await self.controller.initialize()
-                await self.controller.start_game()
-                self.window.show()
-            except Exception as e:
-                print(f"초기화 중 오류 발생: {e}")
-
-    # 애플리케이션 실행
-    app = QApplication(sys.argv)
-    loop = QEventLoop(app)
-    asyncio.set_event_loop(loop)
-
-    test_app = ProsecutorTestApp()
-
-    with loop:
-        loop.create_task(test_app.run())
-        try:
-            loop.run_forever()
-        except KeyboardInterrupt:
-            print("테스트 종료")


### PR DESCRIPTION
작업 내용
- 검사, 변호사화면의 "텍스트입력" 버튼 클릭 시 `QInputDialog`를 통해 사용자 입력을 받도록 구현
- 입력된 텍스트는 `GameController.user_input(text)`로 비동기 전송되며, 내부 메시지 리스트에 추가됨
- `@asyncSlot()`을 활용해 PyQt + qasync 환경에서도 비동기 슬롯이 정상 동작하도록 처리

테스트
- 처음엔 다시 develop 브랜치 다시 풀해서  검사 화면에서 바로 테스트 해보려했는데 계속 경로 오류가 뜬 것을 해결하지 못해 처음 방식으로 테스트 진행함.
- TestApp에서 검사화면 띄운 후 "텍스트입력" 버튼 클릭 → 입력창 정상 표시 확인
- 입력 후 GameController의 `_add_message()` 호출 로그 출력 확인

기타
- 기존의 placeholder 기능(`show_text_input_placeholder()`) 제거
- `MicButton` 기능과 충돌 없이 독립적으로 동작하도록 유지
- 테스트 파일에서 LawyerScreen로 변경후 테스트 진행시  role: '검사'로 유지되고 있는 문제 해결하지 못함